### PR TITLE
defaultUnit

### DIFF
--- a/history.md
+++ b/history.md
@@ -1,3 +1,7 @@
+## 2.0.0 / 2016-01-14
+
+- now unit agnostic, user can provide a unit.
+
 ## 1.0.0 / 2015-10-19
 
 - support jss 3.0

--- a/package.json
+++ b/package.json
@@ -1,19 +1,21 @@
 {
-  "name": "jss-px",
-  "description": "JSS plugin that adds default px unit to numeric values where needed",
-  "version": "1.0.0",
+  "name": "jss-default-unit",
+  "description": "JSS plugin that adds default custom unit to numeric values where needed",
+  "version": "2.0.0",
   "author": {
     "name": "Oleg Slobodskoi",
     "email": "oleg008@gmail.com"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:jsstyles/jss-px.git"
+    "url": "git@github.com:jsstyles/jss-default-unit.git"
   },
   "keywords": [
     "jss",
     "plugin",
-    "px"
+    "px",
+    "unit",
+    "default-unit"
   ],
   "engines": {},
   "scripts": {
@@ -22,8 +24,8 @@
     "build": "npm run clean && npm run build:lib && npm run build:max && npm run build:min",
     "clean": "rimraf ./lib/*",
     "build:lib": "babel src --out-dir lib",
-    "build:max": "NODE_ENV=development webpack src/index.js dist/jss-px.js",
-    "build:min": "NODE_ENV=production webpack src/index.js dist/jss-px.min.js",
+    "build:max": "NODE_ENV=development webpack src/index.js dist/jss-default-unit.js",
+    "build:min": "NODE_ENV=production webpack src/index.js dist/jss-default-unit.min.js",
     "lint": "eslint ./src",
     "prepublish": "npm run all && git push --tags"
   },

--- a/readme.md
+++ b/readme.md
@@ -1,10 +1,10 @@
 ![JSS logo](https://avatars1.githubusercontent.com/u/9503099?v=3&s=60)
 
-## JSS plugin that adds default px unit to numeric values where needed
+## JSS plugin that adds default custom unit to numeric values where needed
 
-This plugin lets you omit the `px` unit from values of style properties.
+This plugin lets you omit the unit from values of style properties.
 
-[Demo](http://jsstyles.github.io/jss-examples/index.html#plugin-jss-px) -
+[Demo](http://jsstyles.github.io/jss-examples/index.html#plugin-jss-default-unit) -
 [JSS](https://github.com/jsstyles/jss)
 
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/jsstyles/jss?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
@@ -14,9 +14,9 @@ This plugin lets you omit the `px` unit from values of style properties.
 
 ```javascript
 import jss from 'jss'
-import px from 'jss-px'
+import defaultUnit from 'jss-default-unit'
 
-jss.use(px())
+jss.use(defaultUnit('px'))
 
 let sheet = jss.createStyleSheet({
   container: {
@@ -47,7 +47,7 @@ console.log(sheet.classes)
 
 ## Issues
 
-File a bug against [jsstyles/jss prefixed with \[jss-px\]](https://github.com/jsstyles/jss/issues/new?title=[jss-px]%20).
+File a bug against [jsstyles/jss prefixed with \[jss-default-unit\]](https://github.com/jsstyles/jss/issues/new?title=[jss-px]%20).
 
 ## Run tests
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,18 +22,18 @@ const cssNumber = {
 }
 
 /**
- * Add px to numeric values.
+ * Add unit to numeric values.
  *
  * @param {Rule} rule
  * @api public
  */
-export default function jssPx() {
+export default function defaultUnit(options = {unit: 'px'}) {
   return rule => {
     let {style} = rule
     if (!style) return
     for (let prop in style) {
       if (!cssNumber[prop] && typeof style[prop] == 'number') {
-        style[prop] += 'px'
+        style[prop] += options.unit
       }
     }
   }

--- a/test/index.html
+++ b/test/index.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="utf-8">
-  <title>jss-px</title>
+  <title>jss-default-unit</title>
   <link rel="stylesheet" href="../node_modules/qunitjs/qunit/qunit.css">
 </head>
 <body>
@@ -10,7 +10,7 @@
   <div id="qunit-fixture"></div>
   <script src="../node_modules/qunitjs/qunit/qunit.js"></script>
   <script src="../node_modules/jss/dist/jss.js"></script>
-  <script src="../dist/jss-px.js"></script>
+  <script src="../dist/jss-default-unit.js"></script>
   <script src="./index.js"></script>
 </body>
 </html>

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,8 @@
 'use strict'
 
-QUnit.module('Px plugin', {
+QUnit.module('defaultUnit plugin', {
   setup: function () {
-    jss.use(jssPx())
+    jss.use(defaultUnit({unit: 'px'}))
   },
   teardown: function () {
     jss.plugins.registry = []

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ if (process.env.NODE_ENV === 'production') {
 
 module.exports = {
   output: {
-    library: 'jssPx',
+    library: 'defaultUnit',
     libraryTarget: 'umd'
   },
   plugins: plugins,


### PR DESCRIPTION
Rename package to jss-default-unit, now can handle different default units other than pixel.

If there's additional stuff you'd like changed in the PR just let me know. @kof 